### PR TITLE
feat: 커뮤니티 게시글 삭제 api 추가

### DIFF
--- a/springboot-monolithic/src/main/java/springbootmonolithic/domain/board/command/controller/BoardController.java
+++ b/springboot-monolithic/src/main/java/springbootmonolithic/domain/board/command/controller/BoardController.java
@@ -48,4 +48,14 @@ public class BoardController {
 
         return ResponseEntity.ok(new ResponseMessage<>(200, "게시글 수정 성공", boardCode));
     }
+
+    @DeleteMapping("/{boardCode}")
+    @Operation(summary = "커뮤니티 게시글 삭제 API")
+    public ResponseEntity<ResponseMessage<Object>> deleteBoard(@PathVariable int boardCode,
+                                                               @RequestParam int memberCode) {
+
+        boardService.deleteBoard(boardCode, memberCode);        // 로그인 적용 시 수정 필요
+
+        return ResponseEntity.ok(new ResponseMessage<>(200, "게시글 삭제 성공", null));
+    }
 }

--- a/springboot-monolithic/src/main/java/springbootmonolithic/domain/board/command/service/BoardService.java
+++ b/springboot-monolithic/src/main/java/springbootmonolithic/domain/board/command/service/BoardService.java
@@ -13,4 +13,5 @@ public interface BoardService {
 
     void updateBoard(int boardCode, BoardUpdateDTO modifiedBoard, List<MultipartFile> images) throws IOException;
 
+    void deleteBoard(int boardCode, int memberCode);
 }

--- a/springboot-monolithic/src/main/java/springbootmonolithic/domain/board/command/service/BoardServiceImpl.java
+++ b/springboot-monolithic/src/main/java/springbootmonolithic/domain/board/command/service/BoardServiceImpl.java
@@ -166,4 +166,25 @@ public class BoardServiceImpl implements BoardService {
             );
         }
     }
+
+    @Transactional
+    @Override
+    public void deleteBoard(int boardCode, int memberCode) {
+
+        // 존재하지 않거나 이미 삭제된 게시글이면 오류 발생
+        Board board = boardRepository.findById(boardCode)
+                .orElseThrow(() -> new BoardNotFoundException("존재하지 않는 게시글입니다."));
+
+        if (!board.isActive()) throw new BoardNotFoundException("삭제된 게시글입니다.");
+
+        // 게시글 작성자가 아니라면 오류 발생
+        if (memberCode != board.getMember().getCode())
+            throw new InvalidMemberException("게시글 삭제 권한이 없습니다.");
+
+        // 게시글 비활성화 처리
+        boardRepository.save(board.toBuilder()
+                                .active(false)
+                                .updatedAt(parsedLocalDateTime)
+                                .build());
+    }
 }


### PR DESCRIPTION
커뮤니티 게시글 삭제 API 추가했습니다.
- 로그인 적용 시 RequestParam 수정 필요
- 삭제 시 게시글 active를 false로 변경