### PR TITLE
feat: 커뮤니티 게시글 상세 조회 기능 추가

### DIFF
--- a/springboot-monolithic/src/main/java/springbootmonolithic/domain/board/query/controller/BoardController.java
+++ b/springboot-monolithic/src/main/java/springbootmonolithic/domain/board/query/controller/BoardController.java
@@ -3,13 +3,11 @@ package springbootmonolithic.domain.board.query.controller;
 import io.swagger.v3.oas.annotations.Operation;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.http.ResponseEntity;
-import org.springframework.web.bind.annotation.GetMapping;
-import org.springframework.web.bind.annotation.RequestMapping;
-import org.springframework.web.bind.annotation.RequestParam;
-import org.springframework.web.bind.annotation.RestController;
+import org.springframework.web.bind.annotation.*;
 import springbootmonolithic.common.PageResponse;
 import springbootmonolithic.common.response.SuccessResponse;
 import springbootmonolithic.domain.board.query.dto.BoardDTO;
+import springbootmonolithic.domain.board.query.dto.SelectedBoardDTO;
 import springbootmonolithic.domain.board.query.service.BoardService;
 
 import java.time.LocalDateTime;
@@ -33,7 +31,9 @@ public class BoardController {
     }
 
     @GetMapping("")
-    @Operation(summary = "커뮤니티 게시글 목록 조회 API - 페이지네이션")
+    @Operation(summary = "커뮤니티 게시글 목록 조회 API",
+                description = "페이지네이션 - 페이지는 1부터 시작" +
+                                " / word에 검색어 넣으면 해당 검색어가 포함된 제목이나 내용의 게시글 목록만 반환")
     public ResponseEntity<SuccessResponse<PageResponse<List<BoardDTO>>>> getBoardList(
                                             @RequestParam(required = false) String word,
                                             @RequestParam (value = "pageNumber", defaultValue = "1") int pageNumber,
@@ -42,5 +42,16 @@ public class BoardController {
         PageResponse<List<BoardDTO>> boardList = boardService.getBoardList(word, pageNumber, pageSize);
 
         return ResponseEntity.ok(new SuccessResponse<>("게시글 목록 조회 성공", boardList, LocalDateTime.now()));
+    }
+
+    @GetMapping("/{boardCode}")
+    @Operation(summary = "커뮤니티 게시글 상세 조회 API",
+                description = "게시글 코드로 해당 게시글 1개 상세 조회")
+    public ResponseEntity<SuccessResponse<SelectedBoardDTO>> getBoard(@PathVariable int boardCode) {
+
+        SelectedBoardDTO board = boardService.getBoard(boardCode);
+
+        return ResponseEntity.ok(new SuccessResponse<>(
+                                boardCode + "번 게시글 상세 조회 성공", board, LocalDateTime.now()));
     }
 }

--- a/springboot-monolithic/src/main/java/springbootmonolithic/domain/board/query/dto/SelectedBoardDTO.java
+++ b/springboot-monolithic/src/main/java/springbootmonolithic/domain/board/query/dto/SelectedBoardDTO.java
@@ -1,0 +1,46 @@
+package springbootmonolithic.domain.board.query.dto;
+
+import com.querydsl.core.annotations.QueryProjection;
+import lombok.*;
+
+import java.util.List;
+
+@NoArgsConstructor
+@AllArgsConstructor
+@Getter
+@Setter
+@ToString
+public class SelectedBoardDTO {
+
+    private int boardCode;              // 게시글 코드
+    private boolean active;             // 게시글 활성화 여부
+    private String createdAt;           // 작성일시
+    private String nickname;            // 작성자 닉네임
+    private String memberImage;         // 작성자 프로필사진
+    private String title;               // 제목
+    private String content;             // 내용
+    private List<String> imageFiles;    // 첨부사진 목록
+    private int replyCount;             // 댓글 수
+//    private int likeCount;              // 좋아요 수
+//    private boolean liked;              // 게시글 좋아요 여부
+//    private boolean bookmarked;         // 게시글 스크랩 여부
+
+    @QueryProjection
+    public SelectedBoardDTO(int boardCode,
+                            boolean active,
+                            String createdAt,
+                            String nickname,
+                            String memberImage,
+                            String title,
+                            String content,
+                            int replyCount) {
+        this.boardCode = boardCode;
+        this.active = active;
+        this.createdAt = createdAt;
+        this.nickname = nickname;
+        this.memberImage = memberImage;
+        this.title = title;
+        this.content = content;
+        this.replyCount = replyCount;
+    }
+}

--- a/springboot-monolithic/src/main/java/springbootmonolithic/domain/board/query/repository/BoardCustomRepository.java
+++ b/springboot-monolithic/src/main/java/springbootmonolithic/domain/board/query/repository/BoardCustomRepository.java
@@ -3,6 +3,7 @@ package springbootmonolithic.domain.board.query.repository;
 import org.springframework.stereotype.Repository;
 import springbootmonolithic.common.criteria.SearchBoardCriteria;
 import springbootmonolithic.domain.board.query.dto.BoardDTO;
+import springbootmonolithic.domain.board.query.dto.SelectedBoardDTO;
 
 import java.util.List;
 
@@ -12,4 +13,8 @@ public interface BoardCustomRepository {
     List<BoardDTO> findBoardList(SearchBoardCriteria criteria);
 
     int getTotalBoardCount(SearchBoardCriteria criteria);
+
+    List<String> findBoardFilesByBoardCode(int boardCode);
+
+    SelectedBoardDTO findBoardByCode(int boardCode);
 }

--- a/springboot-monolithic/src/main/java/springbootmonolithic/domain/board/query/repository/BoardCustomRepositoryImpl.java
+++ b/springboot-monolithic/src/main/java/springbootmonolithic/domain/board/query/repository/BoardCustomRepositoryImpl.java
@@ -42,8 +42,8 @@ public class BoardCustomRepositoryImpl implements BoardCustomRepository {
                 .where(board.active.eq(true)
                         .and(reply.active.eq(true).or(reply.isNull()))
                         .and(resultLikes(criteria.getWord())))
-                .orderBy(board.createdAt.desc())
                 .groupBy(board.code)
+                .orderBy(board.createdAt.desc())
                 .fetch();
 
         return boardList;

--- a/springboot-monolithic/src/main/java/springbootmonolithic/domain/board/query/repository/BoardCustomRepositoryImpl.java
+++ b/springboot-monolithic/src/main/java/springbootmonolithic/domain/board/query/repository/BoardCustomRepositoryImpl.java
@@ -5,7 +5,9 @@ import com.querydsl.core.types.dsl.BooleanExpression;
 import com.querydsl.jpa.impl.JPAQueryFactory;
 import jakarta.persistence.EntityManager;
 import springbootmonolithic.common.criteria.SearchBoardCriteria;
+import springbootmonolithic.domain.board.command.domain.aggregate.entity.Board;
 import springbootmonolithic.domain.board.query.dto.BoardDTO;
+import springbootmonolithic.domain.board.query.dto.SelectedBoardDTO;
 
 import java.util.List;
 
@@ -68,5 +70,41 @@ public class BoardCustomRepositoryImpl implements BoardCustomRepository {
         int totalCount = (totalCountLong != null) ? totalCountLong.intValue() : 0;
 
         return totalCount;
+    }
+
+    @Override
+    public List<String> findBoardFilesByBoardCode(int boardCode) {
+
+        List<String> fileUrls = queryFactory
+                .select(boardFile.url)
+                .from(boardFile)
+                .where(boardFile.board.code.eq(boardCode))
+                .orderBy(boardFile.code.asc())
+                .fetch();
+
+        return !fileUrls.isEmpty() ? fileUrls : null;
+    }
+
+    @Override
+    public SelectedBoardDTO findBoardByCode(int boardCode) {
+
+        SelectedBoardDTO foundBoard = queryFactory
+                .select(Projections.constructor(SelectedBoardDTO.class,
+                        board.code.as("boardCode"),
+                        board.active,
+                        board.createdAt,
+                        member.nickname,
+                        member.image.as("memberImage"),
+                        board.title,
+                        board.content,
+                        reply.code.count().intValue().as("replyCount")))
+                .from(board)
+                .join(board.member, member)
+                .leftJoin(board.replies, reply)
+                .where(board.code.eq(boardCode)
+                        .and(reply.active.eq(true).or(reply.isNull())))
+                .fetchOne();
+
+        return foundBoard;
     }
 }

--- a/springboot-monolithic/src/main/java/springbootmonolithic/domain/board/query/service/BoardService.java
+++ b/springboot-monolithic/src/main/java/springbootmonolithic/domain/board/query/service/BoardService.java
@@ -2,10 +2,13 @@ package springbootmonolithic.domain.board.query.service;
 
 import springbootmonolithic.common.PageResponse;
 import springbootmonolithic.domain.board.query.dto.BoardDTO;
+import springbootmonolithic.domain.board.query.dto.SelectedBoardDTO;
 
 import java.util.List;
 
 public interface BoardService {
 
     PageResponse<List<BoardDTO>> getBoardList(String word, int pageNumber, int pageSize);
+
+    SelectedBoardDTO getBoard(int boardCode);
 }

--- a/springboot-monolithic/src/main/java/springbootmonolithic/domain/board/query/service/BoardServiceImpl.java
+++ b/springboot-monolithic/src/main/java/springbootmonolithic/domain/board/query/service/BoardServiceImpl.java
@@ -3,10 +3,14 @@ package springbootmonolithic.domain.board.query.service;
 import org.modelmapper.ModelMapper;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
 import springbootmonolithic.common.PageResponse;
 import springbootmonolithic.common.criteria.SearchBoardCriteria;
 import springbootmonolithic.domain.board.query.dto.BoardDTO;
+import springbootmonolithic.domain.board.query.dto.SelectedBoardDTO;
 import springbootmonolithic.domain.board.query.repository.BoardCustomRepository;
+import springbootmonolithic.exception.BoardNotFoundException;
+import springbootmonolithic.exception.InvalidDataException;
 
 import java.util.List;
 
@@ -34,5 +38,24 @@ public class BoardServiceImpl implements BoardService{
         PageResponse<List<BoardDTO>> response = new PageResponse<>(boards, pageNumber, pageSize, totalCount);
 
         return response;
+    }
+
+    @Override
+    public SelectedBoardDTO getBoard(int boardCode) {
+
+        // 첨부 이미지 목록 먼저 조회
+        List<String> boardFiles = boardCustomRepository.findBoardFilesByBoardCode(boardCode);
+
+        SelectedBoardDTO selectedBoard = boardCustomRepository.findBoardByCode(boardCode);
+        if (selectedBoard == null) {
+            throw new InvalidDataException("존재하지 않는 게시글입니다.");
+        } else if (!selectedBoard.isActive()) {
+            throw new BoardNotFoundException("삭제된 게시글입니다.");
+        }
+
+        // 조회해온 게시글 DTO에 조회한 이미지 목록 set
+        if (boardFiles != null) selectedBoard.setImageFiles(boardFiles);
+
+        return selectedBoard;
     }
 }


### PR DESCRIPTION
커뮤니티 게시글 상세 조회 api 추가 완료
- QueryDsl로 작성
- 삭제된 게시글이거나 존재하지 않는 게시글일 경우 예외 처리